### PR TITLE
Essential updates for older Salt versions

### DIFF
--- a/sqldeveloper/env.sls
+++ b/sqldeveloper/env.sls
@@ -25,7 +25,7 @@ sqldeveloperhome-alt-set:
   - name: sqldeveloper-home
   - path: {{ sqldeveloper.sqldeveloper_real_home }}
   - require:
-    - sqldeveloperhome-alt-install
+    - alternatives: sqldeveloperhome-alt-install
 
 # Add sqldeveloper to alternatives system
 sqldeveloper-alt-install:
@@ -35,12 +35,12 @@ sqldeveloper-alt-install:
     - path: {{ sqldeveloper.sqldeveloper_realcmd }}
     - priority: {{ sqldeveloper.alt_priority }}
     - require:
-      - sqldeveloperhome-alt-set
+      - alternatives: sqldeveloperhome-alt-set
 
 sqldeveloper-alt-set:
   alternatives.set:
   - name: sqldeveloper
   - path: {{ sqldeveloper.sqldeveloper_realcmd }}
   - require:
-    - sqldeveloper-alt-install
+    - alternatives: sqldeveloper-alt-install
 

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -26,27 +26,26 @@ sqldeveloper-install-dir:
     - makedirs: True
 
 # curl fails (rc=23) if file exists
-{{ archive_file }}:
+sqldeveloper-remove-prev-archive:
   file.absent:
+    - name: {{ archive_file }}
     - require:
       - file: sqldeveloper-install-dir
-    - require_in:
-      - cmd: download-sqldeveloper-archive
 
 download-sqldeveloper-archive:
   cmd.run:
     - name: curl {{ sqldeveloper.dl_opts }} -o '{{ archive_file }}' '{{ sqldeveloper.source_url }}'
     - require:
-      - file: sqldeveloper-install-dir
+      - file: sqldeveloper-remove-prev-archive
 
 unpack-sqldeveloper-archive-to-realhome:
   archive.extracted:
     - name: {{ sqldeveloper.prefix }}
     - source: file://{{ archive_file }}
-    {%- if sqldeveloper.source_hash %}
-    - source_hash: {{ sqldeveloper.source_hash }}
-    {%- endif %}
     - archive_format: {{ sqldeveloper.archive_type }}
+  {%- if sqldeveloper.source_hash %}
+    - source_hash: {{ sqldeveloper.source_hash }}
+  {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
     - if_missing: {{ sqldeveloper.sqldeveloper_realcmd }}
   {% endif %}
@@ -66,11 +65,11 @@ sqldeveloper-desktop-entry:
     - source: salt://sqldeveloper/files/sqldeveloper.desktop
     - name: /home/{{ pillar['user'] }}/Desktop/sqldeveloper.desktop
     - user: {{ pillar['user'] }}
-{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
+  {% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
     - group: users
-{% else %}
+  {% else %}
     - group: {{ pillar['user'] }}
-{% endif %}
+  {% endif %}
     - mode: 755
     - require:
       - archive: unpack-sqldeveloper-archive-to-realhome

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -9,7 +9,7 @@
 #runtime dependency
 sqldeveloper-libaio1:
   pkg.installed:
-    {%- if salt['grains.get']('os') == 'Ubuntu' %}
+    {%- if salt['grains.get']('os') == 'Ubuntu' or salt['grains.get']('os') == 'SUSE' %}
     - name: libaio1
     {%- else %}
     - name: libaio
@@ -29,15 +29,15 @@ sqldeveloper-install-dir:
 {{ archive_file }}:
   file.absent:
     - require:
-      - sqldeveloper-install-dir
+      - file: sqldeveloper-install-dir
     - require_in:
-      - download-sqldeveloper-archive
+      - cmd: download-sqldeveloper-archive
 
 download-sqldeveloper-archive:
   cmd.run:
     - name: curl {{ sqldeveloper.dl_opts }} -o '{{ archive_file }}' '{{ sqldeveloper.source_url }}'
     - require:
-      - sqldeveloper-install-dir
+      - file: sqldeveloper-install-dir
 
 unpack-sqldeveloper-archive-to-realhome:
   archive.extracted:
@@ -47,10 +47,8 @@ unpack-sqldeveloper-archive-to-realhome:
     - source_hash: {{ sqldeveloper.source_hash }}
     {%- endif %}
     - archive_format: {{ sqldeveloper.archive_type }}
-    - user: root
-    - group: root
     - require:
-      - download-sqldeveloper-archive
+      - cmd: download-sqldeveloper-archive
 
 update-sqldeveloper-home-symlink:
   file.symlink:
@@ -58,26 +56,26 @@ update-sqldeveloper-home-symlink:
     - target: {{ sqldeveloper.sqldeveloper_real_home }}
     - force: True
     - require:
-      - unpack-sqldeveloper-archive-to-realhome
+      - archive: unpack-sqldeveloper-archive-to-realhome
 
 sqldeveloper-desktop-entry:
   file.managed:
     - source: salt://sqldeveloper/files/sqldeveloper.desktop
     - name: /home/{{ pillar['user'] }}/Desktop/sqldeveloper.desktop
     - user: {{ pillar['user'] }}
-{% if salt['grains.get']('os_family') == 'Suse' %}
+{% if salt['grains.get']('os_family') == 'Suse' or salt['grains.get']('os') == 'SUSE' %}
     - group: users
 {% else %}
     - group: {{ pillar['user'] }}
 {% endif %}
     - mode: 755
     - require:
-      - unpack-sqldeveloper-archive-to-realhome
+      - archive: unpack-sqldeveloper-archive-to-realhome
 
 remove-sqldeveloper-archive:
   file.absent:
     - name: {{ archive_file }}
     - require:
-      - unpack-sqldeveloper-archive-to-realhome
+      - archive: unpack-sqldeveloper-archive-to-realhome
       
 {%- endif %}

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -47,6 +47,9 @@ unpack-sqldeveloper-archive-to-realhome:
     - source_hash: {{ sqldeveloper.source_hash }}
     {%- endif %}
     - archive_format: {{ sqldeveloper.archive_type }}
+  {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - if_missing: {{ sqldeveloper.sqldeveloper_realcmd }}
+  {% endif %}
     - require:
       - cmd: download-sqldeveloper-archive
 

--- a/sqldeveloper/settings.sls
+++ b/sqldeveloper/settings.sls
@@ -8,12 +8,13 @@
 {%- set minor           = g.get('minor', p.get('minor', '2'))  %}
 {%- set version         = g.get('version', p.get('version', release + '.' + minor + '.0.17.089.1709' )) %}
 
-## ######## YOU MUST CHANGE TO LOCAL MIRROR DUE TO LICENSE ACCEPTANCE/LOGIN REQ. ####### #}
+{########## YOU MUST CHANGE THIS URL TO YOUR LOCAL MIRROR ####### #}
 {%- set mirror  = 'http://download.oracle.com/otn/java/sqldeveloper/' %}
 
 {%- set default_archive_type = 'zip' %}
 {%- set default_prefix       = '/usr/share/oracle/' + oracle_release + '/' %}
 {%- set default_source_url   = mirror + '/sqldeveloper-' + version + '-no-jre.' + default_archive_type %}
+  ###### Hash for version 4.2 linux binary ####
 {%- set default_source_hash  = 'md5=158f54967e563a013b9656918e628427' %}
 
 {%- set source_url           = g.get('source_url', p.get('source_url', default_source_url )) %}


### PR DESCRIPTION
This PR addresses a number of issues in the existing formula.

1. **Salt 2015.8.8 (Beryllium) generates "Requisite declaration XXXXXXXXXXX in SLS sqldeveloper is not formed as a single key dictionary"  errors for all "requires"**-

        Solution: Prefix requisite-type (i.e. - cmd: download-sqldeveloper-archive ) on requires.

2.  **Salt 2016.3 on OpenSuSE Leap evaluates "salt['grains.get']('os_family') == 'Suse'" as False.**

        Solution: Trying "salt['grains.get']('os') == 'SUSE'"  evaluates as True, fixed!!

3. **Current "saltversion" check does not work on opensuse leap.**

       Solution: Twooster on #salt IRC suggested "{% if grains['saltversioninfo'] <= [2016, 11, 6] %}" which works!!

4.  **On older Salt version the archive is never extracted because directory "name" exists-**

        Solution: Reintroduce "if_missing" parameter to archive.extracted for older Salt.

5.  **The "sqldeveloper-libaio1" state fails on opensuse Leap.**

        Solution:  Install libaio1 package if grains.get('os') == SUSE.

6. Getting "recursive requisite" error on fedora/ubuntu for "{{ xxxx }}" statename?

       Solution: Seemingly fixed by renaming state to avoid ID clash.
`-{{ archive_file }}:
 +sqldeveloper-remove-prev-archive:`

Tested successfuly (no pillars):
- Fedora 25 / Salt 2016.11.3.1.fc25
- Ubunutu 17 / Salt 2017.7.0+ds-1
- Opensuse Leap / Salt 2016.3.4.84.13
