### PR TITLE
use onchanges for clearer fail experience; ensure hashchk in older salt.

### DIFF
--- a/sqldeveloper/env.sls
+++ b/sqldeveloper/env.sls
@@ -22,12 +22,10 @@ sqldeveloperhome-alt-install:
 # Set sqldeveloper alternatives
 sqldeveloperhome-alt-set:
   alternatives.set:
-  - name: sqldeveloper-home
-  - path: {{ sqldeveloper.sqldeveloper_real_home }}
-  - require:
-    - alternatives: sqldeveloperhome-alt-install
-  - onchanges:
-    - alternatives: sqldeveloperhome-alt-install
+    - name: sqldeveloper-home
+    - path: {{ sqldeveloper.sqldeveloper_real_home }}
+    - onchanges:
+      - alternatives: sqldeveloperhome-alt-install
 
 # Add sqldeveloper to alternatives system
 sqldeveloper-alt-install:
@@ -36,18 +34,13 @@ sqldeveloper-alt-install:
     - link: {{ sqldeveloper.sqldeveloper_symlink }}
     - path: {{ sqldeveloper.sqldeveloper_realcmd }}
     - priority: {{ sqldeveloper.alt_priority }}
-    - require:
-      - alternatives: sqldeveloperhome-alt-set
     - onchanges:
-      - alternatives: sqldeveloperhome-alt-install
       - alternatives: sqldeveloperhome-alt-set
 
 sqldeveloper-alt-set:
   alternatives.set:
-  - name: sqldeveloper
-  - path: {{ sqldeveloper.sqldeveloper_realcmd }}
-  - require:
-    - alternatives: sqldeveloper-alt-install
-  - onchanges:
-    - alternatives: sqldeveloper-alt-install
+    - name: sqldeveloper
+    - path: {{ sqldeveloper.sqldeveloper_realcmd }}
+    - onchanges:
+      - alternatives: sqldeveloper-alt-install
 

--- a/sqldeveloper/env.sls
+++ b/sqldeveloper/env.sls
@@ -26,6 +26,8 @@ sqldeveloperhome-alt-set:
   - path: {{ sqldeveloper.sqldeveloper_real_home }}
   - require:
     - alternatives: sqldeveloperhome-alt-install
+  - onchanges:
+    - alternatives: sqldeveloperhome-alt-install
 
 # Add sqldeveloper to alternatives system
 sqldeveloper-alt-install:
@@ -36,11 +38,16 @@ sqldeveloper-alt-install:
     - priority: {{ sqldeveloper.alt_priority }}
     - require:
       - alternatives: sqldeveloperhome-alt-set
+    - onchanges:
+      - alternatives: sqldeveloperhome-alt-install
+      - alternatives: sqldeveloperhome-alt-set
 
 sqldeveloper-alt-set:
   alternatives.set:
   - name: sqldeveloper
   - path: {{ sqldeveloper.sqldeveloper_realcmd }}
   - require:
+    - alternatives: sqldeveloper-alt-install
+  - onchanges:
     - alternatives: sqldeveloper-alt-install
 

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -60,7 +60,7 @@ sqldeveloper-unpack-archive:
     - name: {{ sqldeveloper.prefix }}
     - source: file://{{ archive_file }}
     - archive_format: {{ sqldeveloper.archive_type }}
-  {% if grains['saltversioninfo'] > [2016, 11, 6] and sqldeveloper.source_hash %}
+  {% if sqldeveloper.source_hash and grains['saltversioninfo'] > [2016, 11, 6] %}
     - source_hash: {{ sqldeveloper.source_hash }}
   {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -73,7 +73,7 @@ update-sqldeveloper-home-symlink:
     - name: {{ sqldeveloper.orahome }}/sqldeveloper
     - target: {{ sqldeveloper.sqldeveloper_real_home }}
     - force: True
-    - require:
+    - onchanges:
       - archive: sqldeveloper-unpack-archive
 
 sqldeveloper-desktop-entry:
@@ -87,13 +87,13 @@ sqldeveloper-desktop-entry:
     - group: {{ pillar['user'] }}
    {% endif %}
     - mode: 755
-    - require:
+    - onchanges:
       - file: update-sqldeveloper-home-symlink
 
 remove-sqldeveloper-archive:
   file.absent:
     - name: {{ archive_file }}
-    - require:
+    - onchanges:
       - file: update-sqldeveloper-home-symlink
       
 {%- endif %}

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -32,7 +32,7 @@ sqldeveloper-remove-prev-archive:
     - require:
       - file: sqldeveloper-install-dir
 
-download-sqldeveloper-archive:
+sqldeveloper-download-archive:
   cmd.run:
     - name: curl {{ sqldeveloper.dl_opts }} -o '{{ archive_file }}' '{{ sqldeveloper.source_url }}'
     - require:
@@ -64,7 +64,7 @@ sqldeveloper-unpack-archive:
     - if_missing: {{ sqldeveloper.sqldeveloper_realcmd }}
   {% endif %}
     - onchanges:
-      - cmd: download-sqldeveloper-archive
+      - cmd: sqldeveloper-download-archive
 
 update-sqldeveloper-home-symlink:
   file.symlink:

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -51,6 +51,8 @@ unpack-sqldeveloper-archive-to-realhome:
   {% endif %}
     - require:
       - cmd: download-sqldeveloper-archive
+    - onchanges:
+      - cmd: download-sqldeveloper-archive
 
 update-sqldeveloper-home-symlink:
   file.symlink:
@@ -58,6 +60,8 @@ update-sqldeveloper-home-symlink:
     - target: {{ sqldeveloper.sqldeveloper_real_home }}
     - force: True
     - require:
+      - archive: unpack-sqldeveloper-archive-to-realhome
+    - onchanges:
       - archive: unpack-sqldeveloper-archive-to-realhome
 
 sqldeveloper-desktop-entry:
@@ -72,6 +76,8 @@ sqldeveloper-desktop-entry:
   {% endif %}
     - mode: 755
     - require:
+      - archive: unpack-sqldeveloper-archive-to-realhome
+    - onchanges:
       - archive: unpack-sqldeveloper-archive-to-realhome
 
 remove-sqldeveloper-archive:

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -38,17 +38,31 @@ download-sqldeveloper-archive:
     - require:
       - file: sqldeveloper-remove-prev-archive
 
-unpack-sqldeveloper-archive-to-realhome:
+  {% if grains['saltversioninfo'] <= [2016, 11, 6] and sqldeveloper.source_hash %}
+    # See: https://github.com/saltstack/salt/pull/41914
+sqldeveloper-check-archive-hash:
+  module.run:
+    - name: file.check_hash
+    - path: {{ archive_file }}
+    - file_hash: {{ sqldeveloper.source_hash }}
+    - onchanges:
+      - cmd: sqldeveloper-download-archive
+    - require_in:
+      - archive: sqldeveloper-unpack-archive
+  {%- endif %}
+
+sqldeveloper-unpack-archive:
   archive.extracted:
     - name: {{ sqldeveloper.prefix }}
     - source: file://{{ archive_file }}
     - archive_format: {{ sqldeveloper.archive_type }}
-  {%- if sqldeveloper.source_hash %}
+  {% if grains['saltversioninfo'] > [2016, 11, 6] and sqldeveloper.source_hash %}
     - source_hash: {{ sqldeveloper.source_hash }}
   {%- endif %}
+  {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - tar_options: {{ sqldeveloper.unpack_opts }}
     - if_missing: {{ sqldeveloper.sqldeveloper_realcmd }}
-    - require:
-      - cmd: download-sqldeveloper-archive
+  {% endif %}
     - onchanges:
       - cmd: download-sqldeveloper-archive
 
@@ -58,9 +72,9 @@ update-sqldeveloper-home-symlink:
     - target: {{ sqldeveloper.sqldeveloper_real_home }}
     - force: True
     - require:
-      - archive: unpack-sqldeveloper-archive-to-realhome
+      - archive: sqldeveloper-unpack-archive
     - onchanges:
-      - archive: unpack-sqldeveloper-archive-to-realhome
+      - archive: sqldeveloper-unpack-archive
 
 sqldeveloper-desktop-entry:
   file.managed:
@@ -74,14 +88,14 @@ sqldeveloper-desktop-entry:
   {% endif %}
     - mode: 755
     - require:
-      - archive: unpack-sqldeveloper-archive-to-realhome
+      - archive: sqldeveloper-unpack-archive
     - onchanges:
-      - archive: unpack-sqldeveloper-archive-to-realhome
+      - archive: sqldeveloper-unpack-archive
 
 remove-sqldeveloper-archive:
   file.absent:
     - name: {{ archive_file }}
     - require:
-      - archive: unpack-sqldeveloper-archive-to-realhome
+      - archive: sqldeveloper-unpack-archive
       
 {%- endif %}

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -46,9 +46,7 @@ unpack-sqldeveloper-archive-to-realhome:
   {%- if sqldeveloper.source_hash %}
     - source_hash: {{ sqldeveloper.source_hash }}
   {%- endif %}
-  {% if grains['saltversioninfo'] < [2016, 11, 0] %}
     - if_missing: {{ sqldeveloper.sqldeveloper_realcmd }}
-  {% endif %}
     - require:
       - cmd: download-sqldeveloper-archive
     - onchanges:

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -42,7 +42,7 @@ sqldeveloper-download-archive:
     - require_in:
       - archive: sqldeveloper-unpack-archive
 
-  {% if grains['saltversioninfo'] <= [2016, 11, 6] and sqldeveloper.source_hash %}
+  {%- if grains['saltversioninfo'] <= [2016, 11, 6] and sqldeveloper.source_hash %}
     # See: https://github.com/saltstack/salt/pull/41914
 sqldeveloper-check-archive-hash:
   module.run:
@@ -60,7 +60,7 @@ sqldeveloper-unpack-archive:
     - name: {{ sqldeveloper.prefix }}
     - source: file://{{ archive_file }}
     - archive_format: {{ sqldeveloper.archive_type }}
-  {% if sqldeveloper.source_hash and grains['saltversioninfo'] > [2016, 11, 6] %}
+  {%- if sqldeveloper.source_hash and grains['saltversioninfo'] > [2016, 11, 6] %}
     - source_hash: {{ sqldeveloper.source_hash }}
   {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -60,7 +60,6 @@ sqldeveloper-unpack-archive:
     - source_hash: {{ sqldeveloper.source_hash }}
   {%- endif %}
   {% if grains['saltversioninfo'] < [2016, 11, 0] %}
-    - tar_options: {{ sqldeveloper.unpack_opts }}
     - if_missing: {{ sqldeveloper.sqldeveloper_realcmd }}
   {% endif %}
     - onchanges:

--- a/sqldeveloper/settings.sls
+++ b/sqldeveloper/settings.sls
@@ -25,12 +25,14 @@
 {%- endif %}
 
 {%- set default_dl_opts      = ' -s ' %}
+{%- set default_unpack_opts  = 'o' %}
 {%- set default_symlink      = '/usr/bin/sqldeveloper' %}
 {%- set default_real_home    = default_prefix + 'sqldeveloper' %}
 {%- set default_alt_priority = '30' %}
 
 {%- set prefix                 = g.get('prefix', p.get('prefix', default_prefix )) %}
 {%- set dl_opts                = g.get('dl_opts', p.get('dl_opts', default_dl_opts )) %}
+{%- set unpack_opts            = g.get('unpack_opts', p.get('unpack_opts', default_unpack_opts )) %}
 {%- set archive_type           = g.get('archive_type', p.get('archive_type', default_archive_type )) %}
 {%- set sqldeveloper_symlink   = g.get('symlink', p.get('symlink', default_symlink )) %}
 {%- set sqldeveloper_real_home = g.get('real_home', p.get('real_home', default_real_home )) %}
@@ -46,6 +48,7 @@
                                 'source_hash'           : source_hash,
                                 'orahome'               : orahome,
                                 'dl_opts'               : dl_opts,
+                                'unpack_opts'           : unpack_opts,
                                 'archive_type'          : archive_type,
                                 'prefix'                : prefix,
                                 'sqldeveloper_real_home': sqldeveloper_real_home,


### PR DESCRIPTION
incremental improvements:
(1) Currently maven or maven.env state failure triggers dependent states failure unnecessarily => use onchanges.
(2) Ensure download hashcheck happens in older salt.

