### PR TITLE
Fix typo in developer.sls

### DIFF
--- a/sqldeveloper/developer.sls
+++ b/sqldeveloper/developer.sls
@@ -1,4 +1,4 @@
-{% from "sqldeveloper/map.jinja" xml sqldeveloper with context %}
+{% from "sqldeveloper/map.jinja" import sqldeveloper with context %}
 
 {% if sqldeveloper.prefs.user not in (None, 'undefined', 'undefined_user') %}
 


### PR DESCRIPTION
Inadvertently corrupted line in this sqldeveloper.developer statefile.