### PR TITLE
Add Suse support / md5sums for sqlCL package

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,6 @@
 sqldeveloper:
   oracle:
-    # Valid URI terminating in '/' must be given.
+    # Valid URI terminating with slash is needed.
     uri: http://example.com/oracle/sqldeveloper/
     # See products http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html
     version: 4.2.0.17.089.1709
@@ -10,7 +10,7 @@ sqldeveloper:
       sqldeveloper: md5=158f54967e563a013b9656918e628427
   linux:
     # Increase priority for every version installed
-    priority: 190
+    altpriority: 190
   dl:
     retries: 1
     interval: 30

--- a/sqldeveloper/defaults.yaml
+++ b/sqldeveloper/defaults.yaml
@@ -7,7 +7,7 @@ sqldeveloper:
   arch: no-jre
 
   oracle:
-    orahome: /opt/oracle/12_2
+    home: /opt/oracle/12_2
     #Override 'uri' to avoid oracle login
     uri: http://download.oracle.com/otn/java/sqldeveloper/
     #See oracle numbering: https://docs.oracle.com/cd/B28359_01/server.111/b28310/dba004.htm
@@ -25,7 +25,7 @@ sqldeveloper:
 
   linux:
     symlink: /usr/bin/sqldeveloper
-    priority: 170
+    altpriority: 170
 
   prefs:
     user: undefined_user

--- a/sqldeveloper/developer.sls
+++ b/sqldeveloper/developer.sls
@@ -31,7 +31,7 @@ sqldeveloper-desktop-shortcut-add:
     - name: {{ sqldeveloper.homes }}/{{ sqldeveloper.prefs.user }}/Desktop/sqldeveloper.desktop
     - user: {{ sqldeveloper.prefs.user }}
     - makedirs: True
-      {% if salt['grains.get']('os_family') in ('Suse') %} 
+      {% if grains.os_family in ('Suse') %} 
     - group: users
       {% else %}
     - group: {{ sqldeveloper.prefs.user }}
@@ -39,7 +39,8 @@ sqldeveloper-desktop-shortcut-add:
     - mode: 644
     - force: True
     - template: jinja
-    - onlyif: test -f {{ sqldeveloper.realcmd }}
+      #On Suse realcmd cannot be resolved??
+    - onlyif: test -d {{ sqldeveloper.oracle.realhome }}
     - context:
       home: {{ sqldeveloper.oracle.home }}
       command: {{ sqldeveloper.command }}

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -46,8 +46,6 @@ sqldeveloper-extract-{{ pkg }}:
        {% if grains['saltversioninfo'] >= [2016, 11, 0] %}
     - enforce_toplevel: False
        {% endif %}
-    - require_in:
-      - file: sqldeveloper-complete-sqldeveloper
  
 {% endfor %}
 

--- a/sqldeveloper/linuxenv.sls
+++ b/sqldeveloper/linuxenv.sls
@@ -23,7 +23,7 @@ sqldeveloper-linux-profile:
     - context:
       home: '{{ sqldeveloper.oracle.home }}'
     - require:
-      - file: sqldeveloper-libaio1
+      - pkg: sqldeveloper-libaio1
 
 sqldeveloper-update-home-symlink:
   file.symlink:

--- a/sqldeveloper/map.jinja
+++ b/sqldeveloper/map.jinja
@@ -8,11 +8,11 @@
 {% set release = version.split('.')[0] ~ '_' ~ version.split('.')[1] ~ '_' ~ version.split('.')[2] %} 
 
 # OS mapping
-{% set defs.sqldeveloper.oracle.md5 = { 'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078' } %}
 {% set osmap = salt['grains.filter_by']({
 
     'Linux'  : { 'prefix'     : defs.sqldeveloper.prefix ~ '/' ~ release ~ '/',
-                 'oracle:md5' : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0' },
+                 'oracle:md5' : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0',
+                                  'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078', },
      },
     'Windows': { 'prefix'     : 'C:\\oracle\\' ~ release ~ '\\',
                  'tmpdir'     : 'C:\\temp\\oracletmp_' ~ release ~ '\\',
@@ -20,11 +20,13 @@
                  'command'    : '\\sqldeveloper',
                  'arch'       : 'no-jre',
                  'oracle:home': 'C:\\oracle\\' ~ release ~ '\\',
-                 'oracle:md5' : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0' },
+                 'oracle:md5' : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0',
+                                  'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078', },
      },
     'Darwin' : { 'homes'      : '/Users/',
                  'arch'       : 'macosx.app',
-                 'oracle:md5' : { 'sqldeveloper': 'md5=2969c67ea5b856655adff9b8695746f1' },
+                 'oracle:md5' : { 'sqldeveloper': 'md5=2969c67ea5b856655adff9b8695746f1',
+                                  'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078', },
      },
   }, grain='kernel', default='Linux')
 %} 
@@ -32,10 +34,9 @@
 # Merge osmap onto defaults before merging pillars
 {% do defs.sqldeveloper.update(osmap) %}
 {% set sqldeveloper = salt['pillar.get']( 'sqldeveloper', default=defs.sqldeveloper, merge=True) %}
-{% do sqldeveloper.oracle.update({ 
-                   'release' : release,
-                   'uri'     : sqldeveloper.oracle.uri,
-                   'realhome': sqldeveloper.prefix ~ 'sqldeveloper',
-                   'realcmd' : sqldeveloper.prefix ~ 'sqldeveloper' ~ sqldeveloper.command  })
+{% do sqldeveloper.oracle.update({ 'release' : release,
+                         'uri'     : sqldeveloper.oracle.uri,
+                         'realhome': sqldeveloper.prefix ~ 'sqldeveloper',
+                         'realcmd' : sqldeveloper.prefix ~ 'sqldeveloper' ~ sqldeveloper.command,  })
 %}
 


### PR DESCRIPTION
This pull request includes minor enhancements:
1. SUSE support
2. Add MD5 sums for 'sqlCL' package to map.jinja for pillar support
3. Update pillar.example accodingly
4. Workaround issue with developer.sls where 'oracle.realcmd' is not rendering

Suse support verified on OpenSUSE LEAP (42).