### PR TITLE
Minor fixes for sqldeveloper init & developer states

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,8 +34,7 @@ On Linux, the PATH is set for all system users by adding software profile to /et
 
 .. note::
 
-The linux-linuxenv 'priority' pillar value must be updated for each newly installed release/editions.
-
+Enable Debian alternatives by setting nonzero 'altpriority' pillar value; otherwise feature is disabled.
 
 Please see the pillar.example for configuration.
 Tested on Linux (Ubuntu, Fedora, Arch, and Suse), MacOS. Not verified on Windows OS.

--- a/pillar.example
+++ b/pillar.example
@@ -9,8 +9,9 @@ sqldeveloper:
       # no-jre (linux/windows)
       sqldeveloper: md5=158f54967e563a013b9656918e628427
   linux:
-    # Increase priority for every version installed
-    altpriority: 190
+    #Enable Debian alternatives feature by setting nonzero 'altpriority' value here.
+    #Increase same value on each subsequent software installation.
+    #altpriority: 170
   dl:
     retries: 1
     interval: 30

--- a/sqldeveloper/defaults.yaml
+++ b/sqldeveloper/defaults.yaml
@@ -25,7 +25,8 @@ sqldeveloper:
 
   linux:
     symlink: /usr/bin/sqldeveloper
-    altpriority: 170
+    #debian alternatives is disabled by default. Activated via pillar value.
+    altpriority: 0
 
   prefs:
     user: undefined_user

--- a/sqldeveloper/developer.sls
+++ b/sqldeveloper/developer.sls
@@ -25,7 +25,8 @@ sqldeveloper-desktop-shortcut-add:
     - runas: {{ sqldeveloper.prefs.user }}
     - require:
       - file: sqldeveloper-desktop-shortcut-add
-  {% else %}
+  {% elif grains.os not in ('Windows') %}
+  #Linux
   file.managed:
     - source: salt://sqldeveloper/files/sqldeveloper.desktop
     - name: {{ sqldeveloper.homes }}/{{ sqldeveloper.prefs.user }}/Desktop/sqldeveloper.desktop

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -4,8 +4,9 @@ sqldeveloper-create-extract-dirs:
   file.directory:
     - names:
       - '{{ sqldeveloper.tmpdir }}'
-      - '{{ sqldeveloper.oracle.realhome }}'
+      - '{{ sqldeveloper.oracle.home }}'
   {% if grains.os not in ('MacOS', 'Windows') %}
+      - '{{ sqldeveloper.oracle.realhome }}'
     - user: root
     - group: root
     - mode: 755

--- a/sqldeveloper/linuxenv.sls
+++ b/sqldeveloper/linuxenv.sls
@@ -33,9 +33,9 @@ sqldeveloper-update-home-symlink:
     - require:
       - file: sqldeveloper-linux-profile
 
-## Debian Alternatives ##
-
-  {% if grains.os_family not in ('Arch') %}
+  ## Debian Alternatives ##
+  {% if sqldeveloper.linux.altpriority > 0 %}
+     {% if grains.os_family not in ('Arch') %}
 
 # Add swhome to alternatives system
 sqldeveloper-home-alt-install:
@@ -75,6 +75,7 @@ sqldeveloper-alt-set:
     - onchanges:
       - alternatives: sqldeveloper-alt-install
 
+     {% endif %}
   {% endif %}
 
 {% endif %}


### PR DESCRIPTION
PR to fix two minor issues-

1) **sqldeveloper.developer** not verified on Windows => add elif not 'Windows'
2) **sqldeveloper.init** must ensure /opt/jetbrains (**intellij.jetbrains.home**) directory exists
3) Enable Debian Alternatives via 'altpriority' pillar (otherwise disabled)

Verified on OpenSUSE Leap