### PR TITLE
update skip_hashcheck_check

### DIFF
--- a/sqldeveloper/defaults.yaml
+++ b/sqldeveloper/defaults.yaml
@@ -21,7 +21,7 @@ sqldeveloper:
     interval: 30
     retries: 1
     suffix: zip
-    skip_hashcheck: False
+    skip_hashcheck:
 
   linux:
     symlink: /usr/bin/sqldeveloper
@@ -29,7 +29,7 @@ sqldeveloper:
     altpriority: 0
 
   prefs:
-    user: undefined_user
+    user:
     #See http://www.thatjeffsmith.com/archive/2014/05/migrating-oracle-sql-developer-connections-with-passwords/
     xmlurl: 
     xmldir:

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -30,7 +30,7 @@ sqldeveloper-extract-{{ pkg }}:
       - sqldeveloper-create-extract-dirs
     - require_in:
       - archive: sqldeveloper-extract-{{ pkg }}
-  {% if sqldeveloper.dl.skip_hashcheck in ('None', 'False', 'false', 'FALSE') %}
+  {% if sqldeveloper.dl.skip_hashcheck not in ('True', True) %}
   module.run:
     - name: file.check_hash
     - path: '{{ sqldeveloper.tmpdir }}/{{ pkg }}.{{ sqldeveloper.dl.suffix }}'


### PR DESCRIPTION
This PR resolves #13 and has been verified on OpenSUSE.

**Pillars**

```
sqldeveloper:
  oracle:
    uri: http://example.com/downloads/
    version: 4.2.0.17.089.1709
    pkgs: ['sqldeveloper']
    md5:
      # no-jre (linux/windows)
      sqldeveloper: md5=158f54967e563a013b9656918e628427
  linux:
    altpriority: 191
  prefs:
    user: messi
```

**OpenSUSE**

      ```
    ID: sqldeveloper-extract-sqldeveloper
    Function: archive.extracted
        Name: /usr/share/oracle/4_2_0/
      Result: True
     Comment: /tmp/oracletmp/sqldeveloper.zip extracted to /usr/share/oracle/4_2_0/, due to absence of one or more files/dirs
     Started: 20:02:00.202935
    Duration: 4471.354 ms


```