### PR TITLE
Fixes required for MacOS

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -3,12 +3,17 @@ sqldeveloper:
     # Valid URI terminating with slash is needed.
     uri: http://example.com/oracle/sqldeveloper/
     # See products http://www.oracle.com/technetwork/developer-tools/sql-developer/downloads/index.html
-    version: 4.2.0.17.089.1709
+    version: 17.3.1.279.0537
     pkgs: ['sqldeveloper']
     md5:
-      # no-jre (linux/windows)
-      sqldeveloper: md5=158f54967e563a013b9656918e628427
-  linux:
+    {% if grains.os == 'MacOS' %}
+      sqldeveloper: md5=2969c67ea5b856655adff9b8695746f1
+    {% else %}
+      # linux/windows
+      sqldeveloper: md5=5e077af62c1c5a526055cd9f810a3ee0
+    {% endif %}
+      sqlcl: md5=65862f2a970a363a62e1053dc8251078
+  #linux:
     #Enable Debian alternatives feature by setting nonzero 'altpriority' value here.
     #Increase same value on each subsequent software installation.
     #altpriority: 170

--- a/sqldeveloper/defaults.yaml
+++ b/sqldeveloper/defaults.yaml
@@ -1,6 +1,6 @@
 #Default Look Dictionary
 sqldeveloper:
-  prefix: /usr/share/oracle
+  prefix: /usr/local/oracle
   tmpdir: /tmp/oracletmp/
   command: /sqldeveloper
   homes: /home
@@ -8,20 +8,22 @@ sqldeveloper:
 
   oracle:
     home: /opt/oracle/12_2
-    #Override 'uri' to avoid oracle login
+    #Override "uri" to avoid oracle login
     uri: http://download.oracle.com/otn/java/sqldeveloper/
     #See oracle numbering: https://docs.oracle.com/cd/B28359_01/server.111/b28310/dba004.htm
     version: 17.3.1.279.0537
     #See available packages: http://www.oracle.com/technetwork/developer-tools/sql-developer/overview/index.html
-    pkgs: ['sqldeveloper', 'sqlcl']
+    pkgs: ['sqldeveloper', 'sqlcl',]
+    md5:
+      sqldeveloper: md5=5e077af62c1c5a526055cd9f810a3ee0
+      sqlcl: md5=65862f2a970a363a62e1053dc8251078
 
   dl:
+    archive_type: zip
+    suffix: zip
     opts: -s -L
-    #'unpack_opts z' not working (unzip complains "caution: not extracting; -d ignored").
     interval: 30
     retries: 1
-    suffix: zip
-    skip_hashcheck:
 
   linux:
     symlink: /usr/bin/sqldeveloper

--- a/sqldeveloper/developer.sls
+++ b/sqldeveloper/developer.sls
@@ -32,11 +32,12 @@ sqldeveloper-desktop-shortcut-add:
     - name: {{ sqldeveloper.homes }}/{{ sqldeveloper.prefs.user }}/Desktop/sqldeveloper.desktop
     - user: {{ sqldeveloper.prefs.user }}
     - makedirs: True
-      {% if grains.os_family in ('Suse',) %} 
+        {% if grains.os_family in ('Suse',) %}
     - group: users
-      {% else %}
+        {% elif grains.os not in ('MacOS',) %}
+        #For MacOS, just inherit group from Darwin
     - group: {{ sqldeveloper.prefs.user }}
-      {% endif %}
+        {% endif %}
     - mode: 644
     - force: True
     - template: jinja
@@ -64,11 +65,12 @@ sqldeveloper-product-conf-permissions:
     - name: {{ sqldeveloper.homes }}/{{ sqldeveloper.prefs.user }}/.sqldeveloper
     - mode:  744
     - user: {{ sqldeveloper.prefs.user }}
-    {% if grains.os_family in ('Suse',) or grains.os in ('SUSE',) %}
+        {% if grains.os_family in ('Suse',) %}
     - group: users
-    {% else %}
+        {% elif grains.os not in ('MacOS',) %}
+        #For MacOS, just inherit group from Darwin
     - group: {{ sqldeveloper.prefs.user }}
-    {% endif %}
+        {% endif %}
     - recurse:
       - user
       - group
@@ -93,7 +95,7 @@ sqldeveloper-prefs-xmlfile:
         {% if grains.os_family in ('Suse',) %}
     - group: users
         {% elif grains.os not in ('MacOS',) %}
-        #inherit Darwin ownership
+        #For MacOS, just inherit group from Darwin
     - group: {{ sqldeveloper.prefs.user }}
         {% endif %}
     - if_missing: {{ sqldeveloper.homes }}/{{ sqldeveloper.prefs.user }}/{{ sqldeveloper.prefs.xmlfile }}

--- a/sqldeveloper/files/mac_shortcut.sh
+++ b/sqldeveloper/files/mac_shortcut.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-app='SqlDeveloper.app'
+app='SQLDeveloper.app'
 Source="/Applications/$app"
 Destination="{{ homes }}/{{ user }}/Desktop"
 /usr/bin/osascript -e "tell application \"Finder\" to make alias file to POSIX file \"$Source\" at POSIX file \"$Destination\""

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -81,6 +81,5 @@ sqldeveloper-install-sqldeveloper:
   file.absent:
      # source macapp no longer needed
     - name: '{{ sqldeveloper.prefix }}/SQLDeveloper.app'
-    - recurse: True
   {% endif %}
 

--- a/sqldeveloper/init.sls
+++ b/sqldeveloper/init.sls
@@ -20,33 +20,67 @@ sqldeveloper-create-extract-dirs:
 
 sqldeveloper-extract-{{ pkg }}:
   cmd.run:
-    - name: curl {{sqldeveloper.dl.opts}} -o '{{sqldeveloper.tmpdir}}/{{ pkg }}.{{sqldeveloper.dl.suffix}}' {{ url }}
-      {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
+    - name: curl {{sqldeveloper.dl.opts}} -o '{{ sqldeveloper.tmpdir }}{{ pkg }}.{{sqldeveloper.dl.suffix}}' {{ url }}
+    {% if grains['saltversioninfo'] >= [2017, 7, 0] %}
     - retry:
-        attempts: {{ sqldeveloper.dl.retries }}
-        interval: {{ sqldeveloper.dl.interval }}
-      {% endif %}
-    - require:
-      - sqldeveloper-create-extract-dirs
-    - require_in:
-      - archive: sqldeveloper-extract-{{ pkg }}
-  {% if sqldeveloper.dl.skip_hashcheck not in ('True', True,) %}
+      attempts: {{ sqldeveloper.dl.retries }}
+      interval: {{ sqldeveloper.dl.interval }}
+    {% endif %}
+    {%- if grains['saltversioninfo'] <= [2016, 11, 6] %}
+      # Check local archive using hashstring for older Salt
+      # (see https://github.com/saltstack/salt/pull/41914).
   module.run:
     - name: file.check_hash
-    - path: '{{ sqldeveloper.tmpdir }}/{{ pkg }}.{{ sqldeveloper.dl.suffix }}'
+    - path: '{{ sqldeveloper.tmpdir }}{{ pkg }}.{{ sqldeveloper.dl.suffix }}'
     - file_hash: {{ sqldeveloper.oracle.md5[ pkg ] }}
     - onchanges:
       - cmd: sqldeveloper-extract-{{ pkg }}
     - require_in:
       - archive: sqldeveloper-extract-{{ pkg }}
-  {% endif %}
+    {%- endif %}
   archive.extracted:
-    - source: 'file://{{ sqldeveloper.tmpdir }}{{ pkg }}.{{ sqldeveloper.dl.suffix }}'
+    - source: file://{{ sqldeveloper.tmpdir }}{{ pkg }}.{{sqldeveloper.dl.suffix}}
     - name: '{{ sqldeveloper.prefix }}'
-    - archive_format: {{ sqldeveloper.dl.suffix }}
-       {% if grains['saltversioninfo'] >= [2016, 11, 0] %}
+    - archive_format: {{ sqldeveloper.dl.archive_type }}
+        {% if grains['saltversioninfo'] < [2016, 11, 0] %}
+    - if_missing: '{{ sqldeveloper.oracle.realcmd }}'
+        {% endif %}
+        {% if grains['saltversioninfo'] >= [2016, 11, 0] %}
     - enforce_toplevel: False
-       {% endif %}
- 
+        {% endif %}
+        {%- if grains['saltversioninfo'] > [2016, 11, 6] %}
+         #Check local archive using hashstring or hashurl
+    - source_hash: {{ sqldeveloper.oracle.md5[ pkg ] }}
+        {% endif %}
+    - onchanges:
+      - cmd: sqldeveloper-extract-{{ pkg }}
+    - require_in:
+      - file: sqldeveloper-extract-{{ pkg }}
+  file.absent:
+    - name: '{{sqldeveloper.tmpdir}}/{{ pkg }}.{{sqldeveloper.dl.suffix}}'
+    - onchanges:
+      - archive: sqldeveloper-extract-{{ pkg }}
+  {% if grains.os == 'MacOS' %}
+    - require_in:
+      - macpackage: sqldeveloper-install-sqldeveloper
+  {% endif %}
+
 {% endfor %}
+
+  {% if grains.os == 'MacOS' %}
+sqldeveloper-install-sqldeveloper:
+  macpackage.installed:
+    - name: '{{ sqldeveloper.prefix }}/SQLDeveloper.app'
+    - store: False
+    - dmg: False
+    - app: True
+    - force: True
+    - allow_untrusted: True
+    - require_in:
+      - file: sqldeveloper-install-sqldeveloper
+  file.absent:
+     # source macapp no longer needed
+    - name: '{{ sqldeveloper.prefix }}/SQLDeveloper.app'
+    - recurse: True
+  {% endif %}
 

--- a/sqldeveloper/map.jinja
+++ b/sqldeveloper/map.jinja
@@ -7,36 +7,46 @@
 {% set version = salt['pillar.get']('sqldeveloper:oracle:version', defs.sqldeveloper.oracle.version ) %}
 {% set release = version.split('.')[0] ~ '_' ~ version.split('.')[1] ~ '_' ~ version.split('.')[2] %} 
 
-# OS mapping
 {% set osmap = salt['grains.filter_by']({
-
     'Linux'  : { 'prefix'     : defs.sqldeveloper.prefix ~ '/' ~ release ~ '/',
-                 'oracle:md5' : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0',
-                                  'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078', },
-     },
+        },
     'Windows': { 'prefix'     : 'C:\\oracle\\' ~ release ~ '\\',
                  'tmpdir'     : 'C:\\temp\\oracletmp_' ~ release ~ '\\',
                  'homes'      : 'C:\\Users\\',
                  'command'    : '\\sqldeveloper',
                  'arch'       : 'no-jre',
-                 'oracle:home': 'C:\\oracle\\' ~ release ~ '\\',
-                 'oracle:md5' : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0',
-                                  'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078', },
-     },
+        },
     'Darwin' : { 'homes'      : '/Users/',
                  'arch'       : 'macosx.app',
-                 'oracle:md5' : { 'sqldeveloper': 'md5=2969c67ea5b856655adff9b8695746f1',
-                                  'sqlcl': 'md5=65862f2a970a363a62e1053dc8251078', },
-     },
+        },
+  }, grain='kernel', default='Linux')
+%} 
+
+{% set md5map = salt['grains.filter_by']({
+    'Linux'  : { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0',
+                 'sqlcl'       : 'md5=65862f2a970a363a62e1053dc8251078',
+        },
+    'Windows': { 'sqldeveloper': 'md5=5e077af62c1c5a526055cd9f810a3ee0',
+                 'sqlcl'       : 'md5=65862f2a970a363a62e1053dc8251078',
+        },
+    'Darwin' : { 'sqldeveloper': 'md5=2969c67ea5b856655adff9b8695746f1',
+                 'sqlcl'       : 'md5=65862f2a970a363a62e1053dc8251078',
+        },
   }, grain='kernel', default='Linux')
 %} 
 
 # Merge osmap onto defaults before merging pillars
-{% do defs.sqldeveloper.update(osmap) %}
+{% do defs.sqldeveloper.update( osmap ) %}
+{% do defs.sqldeveloper.oracle.md5.update( md5map ) %}
+
 {% set sqldeveloper = salt['pillar.get']( 'sqldeveloper', default=defs.sqldeveloper, merge=True) %}
 {% do sqldeveloper.oracle.update({ 'release' : release,
                          'uri'     : sqldeveloper.oracle.uri,
                          'realhome': sqldeveloper.prefix ~ 'sqldeveloper',
                          'realcmd' : sqldeveloper.prefix ~ 'sqldeveloper' ~ sqldeveloper.command,  })
 %}
+
+{% if grains.os == 'Windows' %}
+    {% do sqldeveloper.oracle.update({ 'home': 'C:\\oracle\\{0}\\'.format(release), }) %}
+{% endif %}
 


### PR DESCRIPTION
This PR includes fixes for executing states on MacOS:  [macos_sqldeveloper.log.txt](https://github.com/saltstack-formulas/sqldeveloper-formula/files/1458502/macos_sqldeveloper.log.txt)

The new Oracle versioning convention (2017.xxx) and latest software release are included.